### PR TITLE
也许暂时修复一个shamwork消息链崩溃bug

### DIFF
--- a/src/main/java/cn/evole/onebot/client/connection/WSClient.java
+++ b/src/main/java/cn/evole/onebot/client/connection/WSClient.java
@@ -62,9 +62,10 @@ public class WSClient extends WebSocketClient {
             } else if (!queue.offer(json)){//事件监听
                 log.error("▌ §c监听错误: {}", message);
             }
-        } catch (
-                JsonSyntaxException e) {
+        } catch (JsonSyntaxException e) {
             log.error("▌ §cJson语法错误:{}", message);
+        } catch (NullPointerException e) {
+            log.error("▌ §c意外的null:{}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
[权宜之计，未测试]

```java
[21:05:07] [pool-13-thread-1/ERROR]: Cannot invoke "cn.evole.onebot.sdk.enums.MsgTypeEnum.equals(Object)" because the return value of "cn.evole.onebot.sdk.entity.ArrayMsg.getType()" is null
```